### PR TITLE
Allow using grip touch instead of press as input

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -301,6 +301,7 @@ namespace Config {
         bool enableTrigger = true;
         bool enableGrip = true;
         bool useTouchForGrip = false;
+        bool allowGripPressWhileUsingTouchInput = false;
         bool delayRightGripInput = true;
         bool delayLeftGripInput = false;
 

--- a/include/config.h
+++ b/include/config.h
@@ -300,6 +300,7 @@ namespace Config {
 
         bool enableTrigger = true;
         bool enableGrip = true;
+        bool useTouchForGrip = false;
         bool delayRightGripInput = true;
         bool delayLeftGripInput = false;
 

--- a/include/hand.h
+++ b/include/hand.h
@@ -390,6 +390,7 @@ struct Hand
     bool grabRequested = false; // True on rising edge of trigger press
     bool releaseRequested = false; // True on falling edge of trigger press
     bool wasObjectGrabbed = false;
+    bool gripPressWasBlockedWithGripTouch = false;
 };
 
 extern Hand *g_rightHand;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -501,6 +501,7 @@ namespace Config {
         if (!RegisterBool("EnableTrigger", options.enableTrigger)) success = false;
         if (!RegisterBool("EnableGrip", options.enableGrip)) success = false;
         if (!RegisterBool("UseTouchForGrip", options.useTouchForGrip)) success = false;
+        if (!RegisterBool("AllowGripPressWhileUsingTouchInput", options.allowGripPressWhileUsingTouchInput)) success = false;
 
         if (!RegisterBool("EnableDrinkPoison", options.enableDrinkPoison)) success = false;
         if (!RegisterBool("OverrideActivateText", options.overrideActivateText)) success = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -223,7 +223,7 @@ namespace Config {
         if (!RegisterFloat("MouthRadius", options.mouthRadius)) success = false;
 
         if (!ReadVector("SelectionBeamStretch", options.selectionBeamStretch)) success = false;
-        
+
         if (!ReadVector("RolloverOffsetRight", options.rolloverOffsetRight)) success = false;
         if (!ReadVector("RolloverOffsetLeft", options.rolloverOffsetLeft)) success = false;
         if (!ReadVector("RolloverRotation", options.rolloverRotation)) success = false;
@@ -435,7 +435,7 @@ namespace Config {
 
         if (!RegisterFloat("grabConstraintFadeInStartAngularMaxForceRatio", options.grabConstraintFadeInStartAngularMaxForceRatio)) success = false;
         if (!RegisterDouble("grabConstraintFadeInTime", options.grabConstraintFadeInTime)) success = false;
-        
+
         if (!RegisterFloat("grabConstraintLinearMaxForceActor", options.grabConstraintLinearMaxForceActor)) success = false;
         if (!RegisterFloat("grabConstraintAngularMaxForceActor", options.grabConstraintAngularMaxForceActor)) success = false;
 
@@ -500,6 +500,7 @@ namespace Config {
 
         if (!RegisterBool("EnableTrigger", options.enableTrigger)) success = false;
         if (!RegisterBool("EnableGrip", options.enableGrip)) success = false;
+        if (!RegisterBool("UseTouchForGrip", options.useTouchForGrip)) success = false;
 
         if (!RegisterBool("EnableDrinkPoison", options.enableDrinkPoison)) success = false;
         if (!RegisterBool("OverrideActivateText", options.overrideActivateText)) success = false;

--- a/src/hand.cpp
+++ b/src/hand.cpp
@@ -4191,6 +4191,9 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
                     if (inputGrip) {
                         if (Config::options.useTouchForGrip) {
                             pControllerState->ulButtonTouched &= ~gripMask;
+                            if (!Config::options.allowGripPressWhileUsingTouchInput) {
+                                pControllerState->ulButtonPressed &= ~gripMask;
+                            }
                         } else {
                             pControllerState->ulButtonPressed &= ~gripMask;
                         }
@@ -4224,6 +4227,9 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
             if (Config::options.enableGrip) {
                 if (Config::options.useTouchForGrip) {
                     pControllerState->ulButtonTouched &= ~gripMask;
+                    if (!Config::options.allowGripPressWhileUsingTouchInput) {
+                        pControllerState->ulButtonPressed &= ~gripMask;
+                    }
                 } else {
                     pControllerState->ulButtonPressed &= ~gripMask;
                 }

--- a/src/hand.cpp
+++ b/src/hand.cpp
@@ -4255,12 +4255,12 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
         if (Config::options.useTouchForGrip) {
             pControllerState->ulButtonTouched &= ~gripMask;
             if (!Config::options.allowGripPressWhileUsingTouchInput) {
-                // Also suppress grip press if not explicitly allowed in config
-                pControllerState->ulButtonPressed &= ~gripMask;
-
                 // Remember that grip press was suppressed too so it can be forced later.
                 // Only reset it on the next Idle state as grip press is always released a few frames before grip touch.
                 gripPressWasBlockedWithGripTouch = gripPressWasBlockedWithGripTouch || (pControllerState->ulButtonPressed & gripMask);
+
+                // Also suppress grip press if not explicitly allowed in config
+                pControllerState->ulButtonPressed &= ~gripMask;
             }
         } else {
             pControllerState->ulButtonPressed &= ~gripMask;

--- a/src/hand.cpp
+++ b/src/hand.cpp
@@ -4141,6 +4141,7 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
 
             inputTrigger = false;
             inputGrip = false;
+            gripPressWasBlockedWithGripTouch = false;
 
             if (triggerRisingEdge) {
                 if (!player->actorState.IsWeaponDrawn()) {
@@ -4192,6 +4193,7 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
                         if (Config::options.useTouchForGrip) {
                             pControllerState->ulButtonTouched &= ~gripMask;
                             if (!Config::options.allowGripPressWhileUsingTouchInput) {
+                                gripPressWasBlockedWithGripTouch = gripPressWasBlockedWithGripTouch || (pControllerState->ulButtonPressed & gripMask);
                                 pControllerState->ulButtonPressed &= ~gripMask;
                             }
                         } else {
@@ -4228,6 +4230,7 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
                 if (Config::options.useTouchForGrip) {
                     pControllerState->ulButtonTouched &= ~gripMask;
                     if (!Config::options.allowGripPressWhileUsingTouchInput) {
+                        gripPressWasBlockedWithGripTouch = gripPressWasBlockedWithGripTouch || (pControllerState->ulButtonPressed & gripMask);
                         pControllerState->ulButtonPressed &= ~gripMask;
                     }
                 } else {
@@ -4245,6 +4248,9 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
             if (inputGrip) {
                 if (Config::options.useTouchForGrip) {
                     pControllerState->ulButtonTouched |= gripMask;
+                    if (!Config::options.allowGripPressWhileUsingTouchInput && gripPressWasBlockedWithGripTouch) {
+                        pControllerState->ulButtonPressed |= gripMask;
+                    }
                 } else {
                     pControllerState->ulButtonPressed |= gripMask;
                 }


### PR DESCRIPTION
In contrast to oculus controllers, on the valve index controllers it is quite hard to hold down the grip button. This quickly leads to accidentally dropped items.

So far the common workaround to this has been, to remap the grip button to the grip touch input using SteamVRs controller Binding UI. This works okay but may cause some unwanted side effects. 
For example the player may use the grip press input for other purposes than higgs, where a stronger force may be desired (close menus, sheathe weapons, etc.).
Other mods (such as the one i'm developing right now ;) ) can also no longer react to grip touch input, independently of grip press.


To fix this this PR adds a new option "useTouchForGrip" (Defaults to false=current behaviour). If enabled Hand::ControllerStateUpdate uses `pControllerState->ulButtonTouched` instead of `pControllerState->ulButtonPressed` to determine wether the grip is activated.

Please note that i was unable to test these changes due to a lack of certain header files ;)