### PR TITLE
Automatically determine grip input method

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -8,7 +8,7 @@
 
 namespace Config {
     enum GripInputMethod {
-        Auto = -1,
+        Auto,
         Press,
         Touch
     };

--- a/include/config.h
+++ b/include/config.h
@@ -7,6 +7,12 @@
 
 
 namespace Config {
+    enum GripInputMethod {
+        Auto = -1,
+        Press,
+        Touch
+    };
+
     struct Options {
         bool debugDrawControllers = false;
 
@@ -301,7 +307,7 @@ namespace Config {
 
         bool enableTrigger = true;
         bool enableGrip = true;
-        int useTouchForGrip = -1;
+        int gripInputMethod = GripInputMethod::Auto;
         bool allowGripPressWhileUsingTouchInput = false;
         bool delayRightGripInput = true;
         bool delayLeftGripInput = false;

--- a/include/config.h
+++ b/include/config.h
@@ -301,7 +301,7 @@ namespace Config {
 
         bool enableTrigger = true;
         bool enableGrip = true;
-        bool useTouchForGrip = false;
+        int useTouchForGrip = -1;
         bool allowGripPressWhileUsingTouchInput = false;
         bool delayRightGripInput = true;
         bool delayLeftGripInput = false;

--- a/include/config.h
+++ b/include/config.h
@@ -300,7 +300,7 @@ namespace Config {
 
         bool enableTrigger = true;
         bool enableGrip = true;
-        bool useTouchForGrip = false;
+        int useTouchForGrip = -1;
         bool allowGripPressWhileUsingTouchInput = false;
         bool delayRightGripInput = true;
         bool delayLeftGripInput = false;

--- a/include/config.h
+++ b/include/config.h
@@ -7,6 +7,12 @@
 
 
 namespace Config {
+    enum GripInputMethod {
+        Auto = -1,
+        Press,
+        Touch
+    };
+
     struct Options {
         bool debugDrawControllers = false;
 
@@ -300,7 +306,7 @@ namespace Config {
 
         bool enableTrigger = true;
         bool enableGrip = true;
-        int useTouchForGrip = -1;
+        int gripInputMethod = GripInputMethod::Auto;
         bool allowGripPressWhileUsingTouchInput = false;
         bool delayRightGripInput = true;
         bool delayLeftGripInput = false;

--- a/include/hand.h
+++ b/include/hand.h
@@ -175,6 +175,14 @@ struct Hand
                 this->fingerNodeNames[i][j] = fingerNodeNames[i][j];
             }
         }
+
+        // Determine whether this controller should use touch for it's grip input by default.
+        if (Config::options.useTouchForGrip == 0 || Config::options.useTouchForGrip == 1) {
+            useTouchForGripThisSession = static_cast<bool>(Config::options.useTouchForGrip);
+        }
+        else {
+            useTouchForGripThisSession = IsHandUsingIndexController(isLeft);
+        }
     };
 
     ~Hand() = delete; // Hacky way to prevent trying to free NiPointers when the game quits and memory is fucked
@@ -391,6 +399,8 @@ struct Hand
     bool releaseRequested = false; // True on falling edge of trigger press
     bool wasObjectGrabbed = false;
     bool gripPressWasBlockedWithGripTouch = false;
+
+    bool useTouchForGripThisSession = false;
 };
 
 extern Hand *g_rightHand;

--- a/include/hand.h
+++ b/include/hand.h
@@ -178,11 +178,11 @@ struct Hand
         }
 
         // Determine whether this controller should use touch for it's grip input by default.
-        if (Config::options.useTouchForGrip == 0 || Config::options.useTouchForGrip == 1) {
-            useTouchForGripThisSession = static_cast<bool>(Config::options.useTouchForGrip);
+        if (Config::options.gripInputMethod == Config::GripInputMethod::Press || Config::options.gripInputMethod == Config::GripInputMethod::Touch) {
+            useTouchForGrip = Config::options.gripInputMethod == Config::GripInputMethod::Touch;
         }
         else {
-            useTouchForGripThisSession = IsHandUsingIndexController(isLeft);
+            useTouchForGrip = IsHandUsingIndexController(isLeft);
         }
     };
 
@@ -404,7 +404,7 @@ struct Hand
     bool wasObjectGrabbed = false;
     bool gripPressWasBlockedWithGripTouch = false;
 
-    bool useTouchForGripThisSession = false;
+    bool useTouchForGrip = false;
 };
 
 extern Hand *g_rightHand;

--- a/include/hand.h
+++ b/include/hand.h
@@ -177,11 +177,11 @@ struct Hand
         }
 
         // Determine whether this controller should use touch for it's grip input by default.
-        if (Config::options.useTouchForGrip == 0 || Config::options.useTouchForGrip == 1) {
-            useTouchForGripThisSession = static_cast<bool>(Config::options.useTouchForGrip);
+        if (Config::options.gripInputMethod == Config::GripInputMethod::Press || Config::options.gripInputMethod == Config::GripInputMethod::Touch) {
+            useTouchForGrip = Config::options.gripInputMethod == Config::GripInputMethod::Touch;
         }
         else {
-            useTouchForGripThisSession = IsHandUsingIndexController(isLeft);
+            useTouchForGrip = IsHandUsingIndexController(isLeft);
         }
     };
 
@@ -400,7 +400,7 @@ struct Hand
     bool wasObjectGrabbed = false;
     bool gripPressWasBlockedWithGripTouch = false;
 
-    bool useTouchForGripThisSession = false;
+    bool useTouchForGrip = false;
 };
 
 extern Hand *g_rightHand;

--- a/include/hand.h
+++ b/include/hand.h
@@ -176,6 +176,14 @@ struct Hand
                 this->fingerNodeNames[i][j] = fingerNodeNames[i][j];
             }
         }
+
+        // Determine whether this controller should use touch for it's grip input by default.
+        if (Config::options.useTouchForGrip == 0 || Config::options.useTouchForGrip == 1) {
+            useTouchForGripThisSession = static_cast<bool>(Config::options.useTouchForGrip);
+        }
+        else {
+            useTouchForGripThisSession = IsHandUsingIndexController(isLeft);
+        }
     };
 
     ~Hand() = delete; // Hacky way to prevent trying to free NiPointers when the game quits and memory is fucked
@@ -395,6 +403,8 @@ struct Hand
     bool releaseRequested = false; // True on falling edge of trigger press
     bool wasObjectGrabbed = false;
     bool gripPressWasBlockedWithGripTouch = false;
+
+    bool useTouchForGripThisSession = false;
 };
 
 extern Hand *g_rightHand;

--- a/include/utils.h
+++ b/include/utils.h
@@ -171,3 +171,4 @@ inline void SetPartNumber(hkUint32 &collisionFilterInfo, UInt32 partNumber) {
     collisionFilterInfo &= ~(0x1f00); // zero out part number
     collisionFilterInfo |= (partNumber & 0x1f) << 8; // set part number
 }
+bool IsHandUsingIndexController(bool leftHand);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -502,7 +502,7 @@ namespace Config {
 
         if (!RegisterBool("EnableTrigger", options.enableTrigger)) success = false;
         if (!RegisterBool("EnableGrip", options.enableGrip)) success = false;
-        if (!RegisterInt("UseTouchForGrip", options.useTouchForGrip)) success = false;
+        if (!RegisterInt("GripInputMethod", options.gripInputMethod)) success = false;
         if (!RegisterBool("AllowGripPressWhileUsingTouchInput", options.allowGripPressWhileUsingTouchInput)) success = false;
 
         if (!RegisterBool("EnableDrinkPoison", options.enableDrinkPoison)) success = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -502,7 +502,7 @@ namespace Config {
 
         if (!RegisterBool("EnableTrigger", options.enableTrigger)) success = false;
         if (!RegisterBool("EnableGrip", options.enableGrip)) success = false;
-        if (!RegisterBool("UseTouchForGrip", options.useTouchForGrip)) success = false;
+        if (!RegisterInt("UseTouchForGrip", options.useTouchForGrip)) success = false;
         if (!RegisterBool("AllowGripPressWhileUsingTouchInput", options.allowGripPressWhileUsingTouchInput)) success = false;
 
         if (!RegisterBool("EnableDrinkPoison", options.enableDrinkPoison)) success = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -500,7 +500,7 @@ namespace Config {
 
         if (!RegisterBool("EnableTrigger", options.enableTrigger)) success = false;
         if (!RegisterBool("EnableGrip", options.enableGrip)) success = false;
-        if (!RegisterBool("UseTouchForGrip", options.useTouchForGrip)) success = false;
+        if (!RegisterInt("UseTouchForGrip", options.useTouchForGrip)) success = false;
         if (!RegisterBool("AllowGripPressWhileUsingTouchInput", options.allowGripPressWhileUsingTouchInput)) success = false;
 
         if (!RegisterBool("EnableDrinkPoison", options.enableDrinkPoison)) success = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -500,7 +500,7 @@ namespace Config {
 
         if (!RegisterBool("EnableTrigger", options.enableTrigger)) success = false;
         if (!RegisterBool("EnableGrip", options.enableGrip)) success = false;
-        if (!RegisterInt("UseTouchForGrip", options.useTouchForGrip)) success = false;
+        if (!RegisterInt("GripInputMethod", options.gripInputMethod)) success = false;
         if (!RegisterBool("AllowGripPressWhileUsingTouchInput", options.allowGripPressWhileUsingTouchInput)) success = false;
 
         if (!RegisterBool("EnableDrinkPoison", options.enableDrinkPoison)) success = false;

--- a/src/hand.cpp
+++ b/src/hand.cpp
@@ -4141,7 +4141,7 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
     triggerDown = Config::options.enableTrigger && (pControllerState->ulButtonPressed & triggerMask);
 
     // Check if the grip is pressed or touched
-    if (Config::options.useTouchForGrip) {
+    if (useTouchForGrip) {
         gripDown = Config::options.enableGrip && (pControllerState->ulButtonTouched & gripMask);
     } else {
         gripDown = Config::options.enableGrip && (pControllerState->ulButtonPressed & gripMask);
@@ -4265,7 +4265,7 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
                 pControllerState->ulButtonPressed |= triggerMask;
             }
             if (inputGrip) {
-                if (Config::options.useTouchForGrip) {
+                if (useTouchForGrip) {
                     pControllerState->ulButtonTouched |= gripMask;
                     if (!Config::options.allowGripPressWhileUsingTouchInput && gripPressWasBlockedWithGripTouch) {
                         pControllerState->ulButtonPressed |= gripMask;
@@ -4287,7 +4287,7 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
 
     if (suppressGrip) {
         // Suppress grip press/touch if requested
-        if (Config::options.useTouchForGrip) {
+        if (useTouchForGrip) {
             pControllerState->ulButtonTouched &= ~gripMask;
             if (!Config::options.allowGripPressWhileUsingTouchInput) {
                 // Remember that grip press was suppressed too so it can be forced later.

--- a/src/hand.cpp
+++ b/src/hand.cpp
@@ -4106,7 +4106,7 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
     triggerDown = Config::options.enableTrigger && (pControllerState->ulButtonPressed & triggerMask);
 
     // Check if the grip is pressed or touched
-    if (Config::options.useTouchForGrip) {
+    if (useTouchForGrip) {
         gripDown = Config::options.enableGrip && (pControllerState->ulButtonTouched & gripMask);
     } else {
         gripDown = Config::options.enableGrip && (pControllerState->ulButtonPressed & gripMask);
@@ -4230,7 +4230,7 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
                 pControllerState->ulButtonPressed |= triggerMask;
             }
             if (inputGrip) {
-                if (Config::options.useTouchForGrip) {
+                if (useTouchForGrip) {
                     pControllerState->ulButtonTouched |= gripMask;
                     if (!Config::options.allowGripPressWhileUsingTouchInput && gripPressWasBlockedWithGripTouch) {
                         pControllerState->ulButtonPressed |= gripMask;
@@ -4252,7 +4252,7 @@ void Hand::ControllerStateUpdate(uint32_t unControllerDeviceIndex, vr_src::VRCon
 
     if (suppressGrip) {
         // Suppress grip press/touch if requested
-        if (Config::options.useTouchForGrip) {
+        if (useTouchForGrip) {
             pControllerState->ulButtonTouched &= ~gripMask;
             if (!Config::options.allowGripPressWhileUsingTouchInput) {
                 // Remember that grip press was suppressed too so it can be forced later.


### PR DESCRIPTION
Config snippet:

```
# Set to 0 to disable
EnableTrigger = 1
EnableGrip = 1

# Only has an effect if EnableGrip is active. Determines the input method for EnableGrip.
# 0 (default) > Automatically determine depending on the detected controller type. Index controllers = grip touch, All other controllers = grip press. If you connect a different controller and restart Skyrim, the input method will update automatically.
# 1 > Always use grip press
# 2 > Always use grip touch
GripInputMethod = 0

# Only applies if EnableGrip is enabled and the Grip input method is touch. Enable this to allow Grip Press inputs while aiming at / holding an object using grip touch. might lead to accidental inputs if the "Click Activation Threshold" is set to a very low value in the SteamVR Controller Bindings UI
AllowGripPressWhileUsingTouchInput = 0
```