### PR TITLE
Add CustomMenu & Mark it as game stopping

### DIFF
--- a/src/menu_checker.cpp
+++ b/src/menu_checker.cpp
@@ -9,6 +9,7 @@ namespace MenuChecker
     };
     
     std::vector<std::string> gameStoppingMenus{
+        "CustomMenu",
         "BarterMenu",
         "Book Menu",
         "Console",
@@ -42,6 +43,7 @@ namespace MenuChecker
     };
 
     std::unordered_map<std::string, bool> menuTypes({
+        { "CustomMenu", false },
         { "BarterMenu", false },
         { "Book Menu", false },
         { "Console", false },


### PR DESCRIPTION
Fixes a bug by adding 'CustomMenu' the tracked menu types

## The Bug

- Player hold something with higgs
- A  [UI Extensions](https://www.nexusmods.com/skyrimspecialedition/mods/17561) menu opens
- Trigger & Grip keys of the hand(s) that are holding are blocked by higgs & their inputs wont reach the game, preventing the player from exiting the Menu, in the worst case.

## Explaination

All Menus of the UI Extensions are implemented as a menu type of `CustomMenu`. As far as I know, all menus of UI Extensions are game stopping. 

`CustomMenu` was missing from the list of game menu ids in skse\reference\higgs\src\menu_checker.cpp. 
This has the consequence, that higgs does not track these menus open-state, and continues to block keys, while any UI Extension menu is open.
